### PR TITLE
Update README.md to use CSCIX65G/SwiftCrossCompilers URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ IMO, the last point is the most important.  This makes is possible to deploy “
 
 ## Easy way to get started:
 
-Just use the installers at: [github](https://github.com/CSCIX65G/swift-mac2arm-x-compile-toolchain/releases).  Then skip the hard way immediately below and proceed directly to: `Using your cross-compiler`
+Just use the installers at: [github](https://github.com/CSCIX65G/SwiftCrossCompilers.git/releases).  Then skip the hard way immediately below and proceed directly to: `Using your cross-compiler`
 
 ## Hard way - Build your own: 
 
@@ -26,8 +26,8 @@ Homebrew coreutils and jq installed with:
 To start, create, the directory and fetch the code to do the build (it’s just a complicated bash script):
 
 ```
-git clone https://github.com/CSCIX65G/swift-mac2arm-x-compile-toolchain.git 
-cd swift-mac2arm-x-compile-toolchain
+git clone https://github.com/CSCIX65G/SwiftCrossCompilers.git
+cd SwiftCrossCompilers
 ```
 To build an arm64 cross compiler (for R/Pi 64-bit OSes):
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ IMO, the last point is the most important.  This makes is possible to deploy “
 
 ## Easy way to get started:
 
-Just use the installers at: [github](https://github.com/CSCIX65G/SwiftCrossCompilers.git/releases).  Then skip the hard way immediately below and proceed directly to: `Using your cross-compiler`
+Just use the installers at: [github](https://github.com/CSCIX65G/SwiftCrossCompilers/releases).  Then skip the hard way immediately below and proceed directly to: `Using your cross-compiler`
 
 ## Hard way - Build your own: 
 


### PR DESCRIPTION
It might be a good idea for the `README.md` to list the CSCX65G URL, as even the original `AlwaysRightInstitute/swift-mac2arm-x-compile-toolchain/README.md` now states:

> 2019-05-11: There is now a great fork of this: SwiftCrossCompilers which provides ready-made toolchains. Highly recommended!

This pull request updates the instructions and release link accordingly.