### PR TITLE
armv7 toolchain is built with wrong name

### DIFF
--- a/Configurations/armv7-5.0-RELEASE.json
+++ b/Configurations/armv7-5.0-RELEASE.json
@@ -1,5 +1,5 @@
 {
-	"archName": "armhf",
+	"archName": "armv7",
 	"version": "5.0",
 	"toolchainSuffix": "RELEASE",
 	"targetArch": "armv7",


### PR DESCRIPTION
It builds "armhf" tools. The armv6 configuration does the same thing.

Attempting to build `helloworld` with the toolchain packaged as-is on your repo results in:

```
$ swift build --destination /Library/Developer/Destinations/armhf-5.0-RELEASE.json 
2019-08-24 22:48:08.711 xcodebuild[5030:21861339] [MT] DVTToolchain: Failed to register toolchain: <DVTToolchain:0x7fe0d064b090:'org.swift.5020190325a':'Swift 5.0 Release 2019-03-25 (a)'>: Error Domain=DVTFoundationErrorDomain Code=-1 "Can't register <DVTFilePath:0x7fe0d06476e0:'/Library/Developer/Toolchains/armhf-5.0-RELEASE.xctoolchain'>; identifier org.swift.5020190325a conflicts with <DVTFilePath:0x7fe0d0647620:'/Library/Developer/Toolchains/arm64-5.0-RELEASE.xctoolchain'>" UserInfo={NSLocalizedDescription=Can't register <DVTFilePath:0x7fe0d06476e0:'/Library/Developer/Toolchains/armhf-5.0-RELEASE.xctoolchain'>; identifier org.swift.5020190325a conflicts with <DVTFilePath:0x7fe0d0647620:'/Library/Developer/Toolchains/arm64-5.0-RELEASE.xctoolchain'>}
[2/2] Linking ./.build/armv7-unknown-linux-gnueabihf/debug/helloworld
```

I'd've just written an issue for this, but you seem to have disable that part of your repo