### PR TITLE
Include -gnu extension in SwiftPM target name

### DIFF
--- a/build_cross_compiler
+++ b/build_cross_compiler
@@ -168,11 +168,7 @@ GNU_EXTENSION=`cat $CONFIG | jq -jc '.gnuExtension' | sed s/\"/\'/g`
 
 TC_TARGET="${TARGET_ARCH}-linux-gnu${GNU_EXTENSION}"
 
-if [ "${GNU_EXTENSION}" != "" ]; then
-    SPM_TARGET="${TARGET_ARCH}-unknown-linux-gnu${GNU_EXTENSION}"
-else
-    SPM_TARGET="${TARGET_ARCH}-unknown-linux"
-fi
+SPM_TARGET="${TARGET_ARCH}-unknown-linux-gnu${GNU_EXTENSION}"
 echo "SPM Target = $SPM_TARGET"
 
 TOOLCHAIN_NAME=${ARCH_NAME}-${VERSION_NUMBER}-${TOOLCHAIN_SUFFIX}


### PR DESCRIPTION
The -gnu extension to the triple is included in the compiler target
both in Debian on real RPi hardware, and Ubuntu in a docker image on a
Mac mini:

RPi:

$ swift --version
Swift version 5.2.3 (swift-5.2.3-RELEASE)
Target: aarch64-unknown-linux-gnu

Docker:

$ docker run arm64v8-swift swift --version
Swift version 5.2.3 (swift-5.2.3-RELEASE)
Target: aarch64-unknown-linux-gnu

Having a mismatched target between the cross compiler and the actual
target means .build/ sub-directory and intermediates are not reused.