### PR TITLE
Create swift-autolink-extract symlink if missing

### DIFF
--- a/build_cross_compiler
+++ b/build_cross_compiler
@@ -415,6 +415,11 @@ fi
 
 rm -rf "$cross_sdk_basename/$linux_sdk_name/usr/share/doc"
 rm -rf "$tmp"
+
+# add missing symlink
+if [ ! -L ${xc_tc_name}/usr/bin/swift-autolink-extract ]; then
+	ln -s swift ${xc_tc_name}/usr/bin/swift-autolink-extract
+fi
 )
 
 echo "Verify SDK Links"
@@ -435,6 +440,7 @@ if [ "${TARGET_ARCH}" == "armv6" ]; then
 	pushd ${cross_tc_basename}/${xc_tc_name}/usr/lib/swift_static/linux; ln -s ./armv6 armv7; popd
 	)
 fi 
+
 
 # --- Generate the destination specification  --------------------------------
 echo "Generate ${ARCH_NAME} destination descriptor"


### PR DESCRIPTION
This isn't present in the MacOS toolchain anymore, but is both included in
and necessary for the Linux toolchain.

Since it's just a symlink to swift itself, it's easier to create if needed.

Without this, builds will fail with:
$ /tmp/Toolchains/arm64-5.2.2-RELEASE.xctoolchain/usr/bin/swift build \
    --destination /tmp/Destinations/arm64-5.2.2-RELEASE.json
<unknown>:0: error: unable to execute command: <unknown>
[0/1] Linking helloworld